### PR TITLE
Entity 매핑 및 Repository 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,42 +1,45 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.3'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'oxahex.asker'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-62:3.6.1'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/oxahex/asker/server/domain/answer/Answer.java
+++ b/src/main/java/oxahex/asker/server/domain/answer/Answer.java
@@ -1,0 +1,69 @@
+package oxahex.asker.server.domain.answer;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import oxahex.asker.server.domain.ask.Ask;
+import oxahex.asker.server.domain.user.User;
+
+@Entity
+@Table(name = "answer")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Answer {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "answer_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "answer_user_id")
+	private User answerUser;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "ask_id")
+	private Ask ask;
+
+	@Column(name = "contents", nullable = false, length = 800)
+	private String contents;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+
+	@Builder
+	public Answer(
+			Long id,
+			User answerUser,
+			Ask ask,
+			String contents
+	) {
+
+		this.id = id;
+		this.answerUser = answerUser;
+		this.ask = ask;
+		this.contents = contents;
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/answer/AnswerRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/answer/AnswerRepository.java
@@ -1,0 +1,9 @@
+package oxahex.asker.server.domain.answer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+}

--- a/src/main/java/oxahex/asker/server/domain/ask/Ask.java
+++ b/src/main/java/oxahex/asker/server/domain/ask/Ask.java
@@ -1,0 +1,71 @@
+package oxahex.asker.server.domain.ask;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import oxahex.asker.server.domain.user.User;
+import oxahex.asker.server.type.AskType;
+
+@Entity
+@Table(name = "ask")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Ask {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ask_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "ask_user_id")
+	private User askUser;
+
+	@Column(name = "contents", nullable = false, length = 800)
+	private String contents;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "ask_type", nullable = false, length = 10)
+	private AskType askType;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Builder
+	public Ask(
+			Long id,
+			User askUser,
+			String contents,
+			AskType askType
+	) {
+
+		this.id = id;
+
+		// 로그인 유저 질문 생성 시 해당 유저 정보 저장 및 유저 객체에 질문 객체 저장
+		if (askUser != null) {
+			this.askUser = askUser;
+			askUser.setAsk(this);
+		}
+
+		this.contents = contents;
+		this.askType = askType;
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/ask/AskRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/ask/AskRepository.java
@@ -1,0 +1,9 @@
+package oxahex.asker.server.domain.ask;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AskRepository extends JpaRepository<Ask, Long> {
+
+}

--- a/src/main/java/oxahex/asker/server/domain/dispatch/Dispatch.java
+++ b/src/main/java/oxahex/asker/server/domain/dispatch/Dispatch.java
@@ -1,0 +1,45 @@
+package oxahex.asker.server.domain.dispatch;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import oxahex.asker.server.domain.ask.Ask;
+import oxahex.asker.server.domain.user.User;
+
+@Entity
+@Table(name = "dispatch")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Dispatch {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "dispatch_id")
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "ask_id", nullable = false)
+	private Ask ask;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "answer_user_id")
+	private User answerUser;
+
+	@Builder
+	public Dispatch(Long id, Ask ask, User answerUser) {
+		this.id = id;
+		this.ask = ask;
+		this.answerUser = answerUser;
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/dispatch/DispatchRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/dispatch/DispatchRepository.java
@@ -1,0 +1,9 @@
+package oxahex.asker.server.domain.dispatch;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DispatchRepository extends JpaRepository<Dispatch, Long> {
+
+}

--- a/src/main/java/oxahex/asker/server/domain/notification/Notification.java
+++ b/src/main/java/oxahex/asker/server/domain/notification/Notification.java
@@ -1,0 +1,80 @@
+package oxahex.asker.server.domain.notification;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import oxahex.asker.server.domain.user.User;
+import oxahex.asker.server.type.NotificationType;
+
+
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "receive_user_id")
+	private User receiveUser;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "notification_type")
+	private NotificationType notificationType;
+
+	@Type(JsonType.class)
+	@Column(name = "front_matter", columnDefinition = "json", nullable = false)
+	private NotificationFrontMatter frontMatter;
+
+	@Column(name = "read_at")
+	private LocalDateTime readAt;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Builder
+	public Notification(
+			Long id,
+			User receiveUser,
+			NotificationType notificationType,
+			Long originId,
+			Long originUserId,
+			String excerpt
+	) {
+		this.id = id;
+		this.receiveUser = receiveUser;
+		this.notificationType = notificationType;
+		this.frontMatter = NotificationFrontMatter.builder()
+				.originId(originId)
+				.originUserId(originUserId)
+				.excerpt(excerpt).build();
+	}
+
+	public void read() {
+		this.readAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/notification/NotificationFrontMatter.java
+++ b/src/main/java/oxahex/asker/server/domain/notification/NotificationFrontMatter.java
@@ -1,0 +1,26 @@
+package oxahex.asker.server.domain.notification;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotificationFrontMatter {
+
+	private Long originId;            // 알림 발생 ID(ASK_USER_ID, ANSWER_USER_ID)
+	private Long originUserId;        // 알림 발생 주체 ID (ASK_ID, ANSWER_ID)
+	private String excerpt;           // ASK or ANSWER CONTENTS 요약
+
+	@Builder
+	public NotificationFrontMatter(
+			Long originId,
+			Long originUserId,
+			String excerpt
+	) {
+
+		this.originId = originId;
+		this.originUserId = originUserId;
+		this.excerpt = excerpt;
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/notification/NotificationRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/notification/NotificationRepository.java
@@ -1,0 +1,9 @@
+package oxahex.asker.server.domain.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/oxahex/asker/server/domain/user/User.java
+++ b/src/main/java/oxahex/asker/server/domain/user/User.java
@@ -1,0 +1,97 @@
+package oxahex.asker.server.domain.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import oxahex.asker.server.domain.ask.Ask;
+import oxahex.asker.server.domain.dispatch.Dispatch;
+import oxahex.asker.server.type.RoleType;
+
+@Entity
+@Table(name = "user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id")
+	private Long id;
+
+	@Column(name = "name", nullable = false, length = 30)
+	private String name;
+
+	@Column(name = "email", unique = true, nullable = false, length = 100)
+	private String email;
+
+	@Column(name = "password", nullable = false, length = 100)
+	private String password;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role", nullable = false, length = 10)
+	private RoleType role;
+
+	@Column(name = "jwt_token")
+	private String jwtToken;
+
+	@OneToMany(mappedBy = "answerUser")
+	private List<Dispatch> dispatches = new ArrayList<>();
+
+	@OneToMany(mappedBy = "askUser")
+	private List<Ask> asks = new ArrayList<>();
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+
+	@Builder
+	public User(
+			Long id,
+			String name,
+			String email,
+			String password,
+			RoleType role,
+			String jwtToken) {
+
+		this.id = id;
+		this.name = name;
+		this.email = email;
+		this.password = password;
+		this.role = role;
+		this.jwtToken = jwtToken;
+	}
+
+	public void setRefreshToken(String refreshToken) {
+		this.jwtToken = refreshToken;
+	}
+
+	public void setDispatch(Dispatch dispatch) {
+		this.dispatches.add(dispatch);
+	}
+
+	public void setAsk(Ask ask) {
+		this.asks.add(ask);
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
@@ -1,0 +1,9 @@
+package oxahex.asker.server.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/oxahex/asker/server/type/AskType.java
+++ b/src/main/java/oxahex/asker/server/type/AskType.java
@@ -1,0 +1,6 @@
+package oxahex.asker.server.type;
+
+public enum AskType {
+
+	USER, DAILY, RANDOM
+}

--- a/src/main/java/oxahex/asker/server/type/NotificationType.java
+++ b/src/main/java/oxahex/asker/server/type/NotificationType.java
@@ -1,0 +1,6 @@
+package oxahex.asker.server.type;
+
+public enum NotificationType {
+
+	ASK, ANSWER
+}

--- a/src/main/java/oxahex/asker/server/type/RoleType.java
+++ b/src/main/java/oxahex/asker/server/type/RoleType.java
@@ -1,0 +1,6 @@
+package oxahex.asker.server.type;
+
+public enum RoleType {
+
+	USER, ADMIN,
+}


### PR DESCRIPTION
#4 
- user
- ask
- answer
- notification
- dispatch

## JSON 타입 컬럼
알림(notification)의 경우 `front_matter`를 json type 컬럼으로 DB에 저장.
알림의 경우 케이스가 다양하므로, 각각의 필드를 따로 만드는 것보다 JSON 타입 컬럼을 사용하는 것이 유연한 방식이라 생각.

```java
private Long originId;            // 알림 발생 ID(ASK_USER_ID, ANSWER_USER_ID)
private Long originUserId;        // 알림 발생 주체 ID (ASK_ID, ANSWER_ID)
private String excerpt;           // ASK or ANSWER CONTENTS 요약
```
알림은 아래 두 케이스일 때 생성.
- 자신의 질문에 답변이 달렸을 때
- 질문이 들어왔을 때

### 자신의 질문에 답변이 달렸을 때
- originId: 답변 아이디
- originUserId: 답변을 단 유저의 아이디
- excerpt: 답변 내용 일부

### 질문이 들어왔을 때
- originId: 질문 아이디
- originUserId: 질문 남긴 유저의 아이디 or 익명 질문인 경우 null
- excerpt: 질문 내용 일부
