### PR TITLE
인증 처리 필터 및 JWT 기반 인가 처리 필터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'io.hypersistence:hypersistence-utils-hibernate-62:3.6.1'
+    implementation 'com.auth0:java-jwt:4.4.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/oxahex/asker/server/config/SecurityConfig.java
+++ b/src/main/java/oxahex/asker/server/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package oxahex.asker.server.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import oxahex.asker.server.error.handler.AuthenticationExceptionHandler;
+import oxahex.asker.server.error.handler.AuthorizationExceptionHandler;
 
 @Slf4j
 @Configuration
@@ -21,6 +24,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final ObjectMapper objectMapper;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -44,6 +49,13 @@ public class SecurityConfig {
 		// 인증, 인가 처리 필터 등록
 
 		// Security Filter 내 기본 예외 처리
+		http
+				.exceptionHandling(exceptionHandler -> {
+					exceptionHandler.authenticationEntryPoint(
+							new AuthenticationExceptionHandler(objectMapper));  // 인증 실패(401)
+					exceptionHandler.accessDeniedHandler(
+							new AuthorizationExceptionHandler(objectMapper));    // 인가 실패(403)
+				});
 
 		return http.build();
 	}

--- a/src/main/java/oxahex/asker/server/config/SecurityConfig.java
+++ b/src/main/java/oxahex/asker/server/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package oxahex.asker.server.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+		http
+				.headers(HeadersConfigurer::disable)  // iframe 비허용
+				.csrf(AbstractHttpConfigurer::disable)
+				.cors(cors -> cors.configurationSource(configurationSource()))  // CORS
+				.httpBasic(AbstractHttpConfigurer::disable)  // 브라우저 팝업 인증 비허용
+				.formLogin(AbstractHttpConfigurer::disable)  // HTTP API 기반 서버이므로 기본 Form Login 비허용
+				.sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+						SessionCreationPolicy.STATELESS));  // JWT 기반 인가 사용을 위해 Stateless로 설정
+
+		// Path Level 진입 제안
+		http
+				.authorizeHttpRequests(request -> {
+					request.requestMatchers("/api/**").permitAll();
+					request.anyRequest().authenticated();
+				});
+
+		// 인증, 인가 처리 필터 등록
+
+		// Security Filter 내 기본 예외 처리
+
+		return http.build();
+	}
+
+
+	public CorsConfigurationSource configurationSource() {
+
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.addAllowedHeader("*");
+		configuration.addAllowedMethod("*");  // GET, POST, PUT, DELETE JavaScript 요청 모두 허용
+		configuration.addAllowedOriginPattern("*");  // 모든 주소 허용 -> 이후 변경(프론트쪽 Origin만 허용하도록)
+		configuration.setAllowCredentials(true);  // 클라이언트 쿠키 요청 허용
+
+		// 모든 주소 요청에 위 설정 적용
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("**", configuration);
+
+		return source;
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
@@ -1,9 +1,12 @@
 package oxahex.asker.server.domain.user;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/oxahex/asker/server/dto/LoginDto.java
+++ b/src/main/java/oxahex/asker/server/dto/LoginDto.java
@@ -1,0 +1,43 @@
+package oxahex.asker.server.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import oxahex.asker.server.domain.user.User;
+import oxahex.asker.server.type.RoleType;
+
+public class LoginDto {
+
+	@Getter
+	@Setter
+	public static class LoginReqDto {
+
+		@NotEmpty(message = "로그인에 사용할 이메일을 입력해주세요.")
+		@Pattern(regexp = "^[a-zA-Z0-9+-_.]{1,30}@[a-zA-Z0-9-]+\\.[a-zA-Z]+$", message = "올바른 이메일 형식이 아닙니다(이메일 아이디는 최대 30자까지 입력 가능합니다).")
+		private String email;
+
+		@NotEmpty(message = "로그인에 사용할 비밀번호를 입력해주세요.")
+		@Size(min = 8, max = 20, message = "최소 8글자, 최대 20글자의 비밀번호를 입력해주세요.")
+		private String password;
+
+	}
+
+	@Getter
+	@Setter
+	public static class LoginResDto {
+
+		private String name;
+		private String email;
+		private RoleType role;
+		private String token;
+
+		public LoginResDto(User user, String token) {
+			this.name = user.getName();
+			this.email = user.getEmail();
+			this.role = user.getRole();
+			this.token = token;
+		}
+	}
+}

--- a/src/main/java/oxahex/asker/server/dto/ResponseDto.java
+++ b/src/main/java/oxahex/asker/server/dto/ResponseDto.java
@@ -1,0 +1,8 @@
+package oxahex.asker.server.dto;
+
+import lombok.Getter;
+
+@Getter
+public record ResponseDto<T>(String message, T data) {
+
+}

--- a/src/main/java/oxahex/asker/server/dto/ResponseDto.java
+++ b/src/main/java/oxahex/asker/server/dto/ResponseDto.java
@@ -1,8 +1,5 @@
 package oxahex.asker.server.dto;
 
-import lombok.Getter;
-
-@Getter
 public record ResponseDto<T>(String message, T data) {
 
 }

--- a/src/main/java/oxahex/asker/server/error/AccessException.java
+++ b/src/main/java/oxahex/asker/server/error/AccessException.java
@@ -1,0 +1,18 @@
+package oxahex.asker.server.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import oxahex.asker.server.type.ErrorType;
+
+@Getter
+public class AccessException extends AccessDeniedException {
+
+	private final HttpStatus httpStatus = HttpStatus.FORBIDDEN;
+	String errorMessage;
+
+	public AccessException(ErrorType errorType) {
+		super(errorType.getErrorMessage());
+		this.errorMessage = errorType.getErrorMessage();
+	}
+}

--- a/src/main/java/oxahex/asker/server/error/AuthException.java
+++ b/src/main/java/oxahex/asker/server/error/AuthException.java
@@ -1,0 +1,18 @@
+package oxahex.asker.server.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import oxahex.asker.server.type.ErrorType;
+
+@Getter
+public class AuthException extends AuthenticationException {
+
+	private final HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
+	String errorMessage;
+
+	public AuthException(ErrorType errorType) {
+		super(errorType.getErrorMessage());
+		this.errorMessage = errorType.getErrorMessage();
+	}
+}

--- a/src/main/java/oxahex/asker/server/error/handler/AuthenticationExceptionHandler.java
+++ b/src/main/java/oxahex/asker/server/error/handler/AuthenticationExceptionHandler.java
@@ -1,0 +1,37 @@
+package oxahex.asker.server.error.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import oxahex.asker.server.type.ErrorType;
+import oxahex.asker.server.utils.ResponseUtil;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthenticationExceptionHandler implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+	
+	@Override
+	public void commence(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			AuthenticationException authException
+	) throws IOException, ServletException {
+
+		log.error("[인증 오류][msg={}]", authException.getMessage());
+
+		ResponseUtil.failure(
+				objectMapper,
+				response,
+				ErrorType.AUTHENTICATION_FAILURE.getHttpStatus(),
+				ErrorType.AUTHENTICATION_FAILURE.getErrorMessage()
+		);
+	}
+}

--- a/src/main/java/oxahex/asker/server/error/handler/AuthorizationExceptionHandler.java
+++ b/src/main/java/oxahex/asker/server/error/handler/AuthorizationExceptionHandler.java
@@ -1,0 +1,37 @@
+package oxahex.asker.server.error.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import oxahex.asker.server.type.ErrorType;
+import oxahex.asker.server.utils.ResponseUtil;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthorizationExceptionHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void handle(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			AccessDeniedException accessDeniedException
+	) throws IOException, ServletException {
+
+		log.error("[인가 오류][msg={}]", accessDeniedException.getMessage());
+
+		ResponseUtil.failure(
+				objectMapper,
+				response,
+				ErrorType.AUTHORIZATION_FAILURE.getHttpStatus(),
+				ErrorType.AUTHORIZATION_FAILURE.getErrorMessage()
+		);
+	}
+}

--- a/src/main/java/oxahex/asker/server/security/AuthUser.java
+++ b/src/main/java/oxahex/asker/server/security/AuthUser.java
@@ -1,0 +1,58 @@
+package oxahex.asker.server.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import oxahex.asker.server.domain.user.User;
+
+@Getter
+@RequiredArgsConstructor
+public class AuthUser implements UserDetails {
+
+	private User user;
+
+	public AuthUser(User user) {
+		this.user = user;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new SimpleGrantedAuthority(this.user.getRole().name()));
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return this.user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return this.user.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/oxahex/asker/server/security/AuthenticationFilter.java
+++ b/src/main/java/oxahex/asker/server/security/AuthenticationFilter.java
@@ -13,7 +13,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import oxahex.asker.server.cache.RedisRepository;
 import oxahex.asker.server.dto.LoginDto.LoginReqDto;
 import oxahex.asker.server.dto.LoginDto.LoginResDto;
 import oxahex.asker.server.error.AuthException;
@@ -26,7 +25,6 @@ import oxahex.asker.server.utils.ResponseUtil;
 @RequiredArgsConstructor
 public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
-	private final RedisRepository redisRepository;
 	private final ObjectMapper objectMapper;
 
 	@Override

--- a/src/main/java/oxahex/asker/server/security/AuthenticationFilter.java
+++ b/src/main/java/oxahex/asker/server/security/AuthenticationFilter.java
@@ -1,0 +1,105 @@
+package oxahex.asker.server.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import oxahex.asker.server.cache.RedisRepository;
+import oxahex.asker.server.dto.LoginDto.LoginReqDto;
+import oxahex.asker.server.dto.LoginDto.LoginResDto;
+import oxahex.asker.server.error.AuthException;
+import oxahex.asker.server.service.JwtTokenService;
+import oxahex.asker.server.type.ErrorType;
+import oxahex.asker.server.type.JwtTokenType;
+import oxahex.asker.server.utils.ResponseUtil;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+	private final RedisRepository redisRepository;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public Authentication attemptAuthentication(
+			HttpServletRequest request,
+			HttpServletResponse response
+	) throws AuthenticationException {
+
+		try {
+
+			LoginReqDto loginReqDto =
+					objectMapper.readValue(request.getInputStream(), LoginReqDto.class);
+
+			log.info("[이메일 로그인 시도][{}]", loginReqDto.getEmail());
+
+			// 강제 로그인 처리
+			UsernamePasswordAuthenticationToken authenticationToken =
+					new UsernamePasswordAuthenticationToken(
+							loginReqDto.getEmail(), loginReqDto.getPassword()
+					);
+
+			// 검증 성공 시 진행
+			return this.getAuthenticationManager().authenticate(authenticationToken);
+
+		} catch (Exception e) {
+
+			log.error("[ERROR] 이메일 로그인 에러");
+			throw new AuthException(ErrorType.AUTHENTICATION_FAILURE);
+		}
+	}
+
+	@Override
+	protected void successfulAuthentication(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			FilterChain chain,
+			Authentication authResult
+	) throws IOException, ServletException {
+
+		log.info("[이메일 인증 성공]");
+
+		AuthUser authUser = (AuthUser) authResult.getPrincipal();
+
+		// Access Token
+		String accessToken = JwtTokenService.create(authUser, JwtTokenType.ACCESS_TOKEN);
+
+		// Refresh Token
+		String refreshToken = JwtTokenService.create(authUser, JwtTokenType.REFRESH_TOKEN);
+
+		// Token, 로그인 유저 정보 응답
+		ResponseUtil.success(
+				objectMapper,
+				response,
+				HttpStatus.OK,
+				"정상적으로 로그인 되었습니다.",
+				new LoginResDto(authUser.getUser(), accessToken)
+		);
+	}
+
+	@Override
+	protected void unsuccessfulAuthentication(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			AuthenticationException failed
+	) throws IOException, ServletException {
+
+		log.info("[이메일 인증 실패]");
+
+		ResponseUtil.failure(
+				objectMapper,
+				response,
+				HttpStatus.UNAUTHORIZED,
+				failed.getMessage()
+		);
+	}
+}

--- a/src/main/java/oxahex/asker/server/security/AuthorizationFilter.java
+++ b/src/main/java/oxahex/asker/server/security/AuthorizationFilter.java
@@ -1,0 +1,55 @@
+package oxahex.asker.server.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import oxahex.asker.server.service.JwtTokenService;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthorizationFilter extends OncePerRequestFilter {
+
+	private static final String HEADER = "Authorization";
+	private static final String PREFIX = "Bearer ";
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			FilterChain filterChain
+	) throws ServletException, IOException {
+
+		// Access Token이 헤더에 없는 경우 인가 처리하지 않음
+		if (request.getHeader(HEADER) == null) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		log.info("[JWT 유효성 검사][{}]", request.getRequestURI());
+
+		// Access Token
+		String accessToken = request.getHeader(HEADER).replace(PREFIX, "");
+
+		// 만료 여부 검증 및 유효 토큰 반환
+		AuthUser authUser = JwtTokenService.verify(accessToken);
+
+		Authentication authentication =
+				new UsernamePasswordAuthenticationToken(
+						authUser, null, authUser.getAuthorities()
+				);
+
+		// Security Context 저장
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/oxahex/asker/server/service/AuthService.java
+++ b/src/main/java/oxahex/asker/server/service/AuthService.java
@@ -26,6 +26,8 @@ public class AuthService implements UserDetailsService {
 		User user = userRepository.findByEmail(username)
 				.orElseThrow(() -> new AuthException(ErrorType.AUTHENTICATION_FAILURE));
 
+		// TODO: 토큰 발급 여기에서
+
 		return new AuthUser(user);
 	}
 }

--- a/src/main/java/oxahex/asker/server/service/AuthService.java
+++ b/src/main/java/oxahex/asker/server/service/AuthService.java
@@ -1,0 +1,19 @@
+package oxahex.asker.server.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService implements UserDetailsService {
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		return null;
+	}
+}

--- a/src/main/java/oxahex/asker/server/service/AuthService.java
+++ b/src/main/java/oxahex/asker/server/service/AuthService.java
@@ -6,14 +6,26 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import oxahex.asker.server.domain.user.User;
+import oxahex.asker.server.domain.user.UserRepository;
+import oxahex.asker.server.error.AuthException;
+import oxahex.asker.server.security.AuthUser;
+import oxahex.asker.server.type.ErrorType;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService implements UserDetailsService {
 
+	private final UserRepository userRepository;
+
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		return null;
+
+		log.info("[이메일 유저 인증][email={}]", username);
+		User user = userRepository.findByEmail(username)
+				.orElseThrow(() -> new AuthException(ErrorType.AUTHENTICATION_FAILURE));
+
+		return new AuthUser(user);
 	}
 }

--- a/src/main/java/oxahex/asker/server/service/JwtTokenService.java
+++ b/src/main/java/oxahex/asker/server/service/JwtTokenService.java
@@ -1,0 +1,88 @@
+package oxahex.asker.server.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import oxahex.asker.server.domain.user.User;
+import oxahex.asker.server.security.AuthUser;
+import oxahex.asker.server.type.JwtTokenType;
+import oxahex.asker.server.type.RoleType;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+	private static final String HEADER = "Authorization";
+	private static final String KEY_ID = "id";
+	private static final String KEY_ROLE = "role";
+	private static String JWT_TOKEN_KEY;
+
+	/**
+	 * JWT Token 생성, 발급
+	 *
+	 * @param authUser  Email, Password 인증 완료 된 UserDetails 객체
+	 * @param tokenType 생성할 토큰 타입(ACCESS_TOKEN, REFRESH_TOKEN)
+	 * @return JWT Token
+	 */
+	public static String create(AuthUser authUser, JwtTokenType tokenType) {
+
+		log.info("[JWT {} 생성][{}]", tokenType.name(), authUser.getUsername());
+
+		Date now = new Date(System.currentTimeMillis());
+		Date expiredDate = new Date(now.getTime() + tokenType.getExpireTime());
+
+		return JWT.create()
+				.withSubject(authUser.getUsername())
+				.withIssuedAt(now)
+				.withExpiresAt(expiredDate)
+				.withClaim(KEY_ID, authUser.getUser().getId())
+				.withClaim(KEY_ROLE, authUser.getUser().getRole().name())
+				.sign(Algorithm.HMAC256(JWT_TOKEN_KEY));
+	}
+
+	/**
+	 * 토큰 검증
+	 * <p>검증된 유저의 경우 강제 로그인 처리를 위해 UserDetails 객체를 만들어 반환
+	 *
+	 * @param token 검증할 토큰
+	 * @return 검증된 유저의 UserDetails 객체
+	 */
+	public static AuthUser verify(String token) {
+
+		log.info("[토큰 검증][{}]", token);
+
+		DecodedJWT decodedJWT =
+				JWT.require(Algorithm.HMAC256(JWT_TOKEN_KEY)).build().verify(token);
+
+		Long id = decodedJWT.getClaim(KEY_ID).asLong();
+		String email = decodedJWT.getSubject();
+		String role = decodedJWT.getClaim(KEY_ROLE).asString();
+
+		User user = User.builder()
+				.id(id)
+				.email(email)
+				.role(RoleType.valueOf(role))
+				.build();
+
+		log.info("[토큰 검증 완료][id={}][email={}][role={}]", id, email, role);
+
+		return new AuthUser(user);
+	}
+
+	/**
+	 * JWT_SECRET_KEY static 설정
+	 * TODO: JWT 관련 데이터(Authorization Header, Secret Key, Bearer , Expire Time 등)를 관리하는 VO를 따로 만드는 것 고려
+	 *
+	 * @param key @Value 주입 받은 JWT SECRET KEY
+	 */
+	@Value("${spring.jwt.key}")
+	private void setKey(String key) {
+		JWT_TOKEN_KEY = key;
+	}
+}

--- a/src/main/java/oxahex/asker/server/type/ErrorType.java
+++ b/src/main/java/oxahex/asker/server/type/ErrorType.java
@@ -1,0 +1,18 @@
+package oxahex.asker.server.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+
+	// 인증/인가
+	AUTHENTICATION_FAILURE(HttpStatus.UNAUTHORIZED, "인증 정보가 없거나 올바르지 않습니다."),
+	AUTHORIZATION_FAILURE(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+	TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 토큰입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+}

--- a/src/main/java/oxahex/asker/server/type/JwtTokenType.java
+++ b/src/main/java/oxahex/asker/server/type/JwtTokenType.java
@@ -1,0 +1,15 @@
+package oxahex.asker.server.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtTokenType {
+
+	ACCESS_TOKEN(1000 * 60 * 60),               // 1 hour
+	REFRESH_TOKEN(1000 * 60 * 60 * 24 * 7),     // 1 week
+	TEST_TOKEN(1000);                           // 1 sec(for test)
+
+	private final long expireTime;
+}

--- a/src/main/java/oxahex/asker/server/utils/ResponseUtil.java
+++ b/src/main/java/oxahex/asker/server/utils/ResponseUtil.java
@@ -1,0 +1,60 @@
+package oxahex.asker.server.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import oxahex.asker.server.dto.ResponseDto;
+
+@Slf4j
+public class ResponseUtil {
+
+	public static void success(
+			ObjectMapper objectMapper,
+			HttpServletResponse response,
+			HttpStatus status,
+			String message,
+			Object dto
+	) {
+		try {
+
+			ResponseDto<?> responseDto = new ResponseDto<>(message, dto);
+
+			String responseBody = objectMapper.writeValueAsString(responseDto);
+
+			response.setStatus(status.value());
+			response.setCharacterEncoding("utf-8");
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+			response.getWriter().write(responseBody);
+
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+
+	// TODO: Error Type Enum을 인자로 받도록 리팩토링 하면 어떨지?
+	public static void failure(
+			ObjectMapper objectMapper,
+			HttpServletResponse response,
+			HttpStatus status,
+			String message
+	) {
+		try {
+
+			ResponseDto<?> responseDto = new ResponseDto<>(message, null);
+
+			String responseBody = objectMapper.writeValueAsString(responseDto);
+
+			response.setStatus(status.value());
+			response.setCharacterEncoding("utf-8");
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+			response.getWriter().write(responseBody);
+
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
#3 
- 인증 처리 필터 구현
- JWT 기반 인가 처리 필터 구현
- 공통 응답 DTO 생성
- Security Filter Chain 내부 오류 시 핸들러 구현
- Controller를 거치지 않는 응답 생성 유틸 클래스 구현

## 인증 처리 필터구현
- `UsernamePasswordAuthenticationFilter` 구현체
- 이메일, 패스워드 일치 + DB 저장된 유저일 때(성공 시)  JWT 토큰 발급 및 로그인 성공 응답
- 이메일, 패스워드 불일치 시(실패 시) 401 응답

## JWT 기반 인가 처리 필터 구현
- 요청 당 한 번만 실행되는 것을 보장하기 위해 `OncePerRequestFilter`를 구현
- Authorization 헤더 확인 후 유효성 검사 진행
- 유효한 토큰인 경우 인증 객체 생성 후 Security Context 저장
