### PR TITLE
이메일 회원가입 기능 구현

### DIFF
--- a/src/main/java/oxahex/asker/server/controller/AuthController.java
+++ b/src/main/java/oxahex/asker/server/controller/AuthController.java
@@ -1,0 +1,49 @@
+package oxahex.asker.server.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import oxahex.asker.server.dto.JoinDto.JoinReqDto;
+import oxahex.asker.server.dto.JoinDto.JoinResDto;
+import oxahex.asker.server.dto.ResponseDto;
+import oxahex.asker.server.service.AuthService;
+
+@Slf4j
+@RestController
+@PreAuthorize("permitAll()")
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private static final String HEADER = "Authorization";
+	private static final String PREFIX = "Bearer ";
+	private final AuthService authService;
+
+	/**
+	 * 이메일 회원가입
+	 *
+	 * @param joinReqDto 이메일 회원가입 요청 Body
+	 * @return 회원가입 유저 정보
+	 */
+	@PostMapping("/join")
+	public ResponseEntity<ResponseDto<JoinResDto>> joinWithEmail(
+			@RequestBody @Valid JoinReqDto joinReqDto
+	) {
+
+		log.info("[회원가입 요청][email={}]", joinReqDto.getEmail());
+
+		JoinResDto joinResDto = authService.createUser(joinReqDto);
+
+		return new ResponseEntity<>(
+				new ResponseDto<>("회원 가입이 완료되었습니다.", joinResDto),
+				HttpStatus.CREATED
+		);
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
 
+	boolean existsByEmail(String email);
 }

--- a/src/main/java/oxahex/asker/server/dto/JoinDto.java
+++ b/src/main/java/oxahex/asker/server/dto/JoinDto.java
@@ -1,0 +1,48 @@
+package oxahex.asker.server.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import oxahex.asker.server.domain.user.User;
+import oxahex.asker.server.type.RoleType;
+
+public class JoinDto {
+
+	@Getter
+	@Setter
+	public static class JoinReqDto {
+
+		@NotEmpty(message = "이름(닉네임)을 입력해주세요.")
+		@Pattern(regexp = "^[a-zA-Z가-힣]{2,12}", message = "한글 또는 영문으로 이루어진 최소 2글자, 최대 12자의 이름을 입력해주세요.")
+		private String name;
+
+		// 최대 30자
+		@NotEmpty(message = "로그인에 사용할 이메일을 입력해주세요.")
+		@Pattern(regexp = "^[a-zA-Z0-9+-_.]{1,30}@[a-zA-Z0-9-]+\\.[a-zA-Z]+$", message = "올바른 이메일 형식이 아닙니다(이메일 아이디는 최대 30자까지 입력 가능합니다).")
+		@Size(max = 50, message = "50자 미만의 이메일을 입력해주세요.")
+		private String email;
+
+		// 8 ~ 20
+		@NotEmpty(message = "로그인에 사용할 비밀번호를 입력해주세요.")
+		@Size(min = 8, max = 20, message = "최소 8글자, 최대 20글자의 비밀번호를 입력해주세요.")
+		private String password;
+	}
+
+	@Getter
+	@Setter
+	public static class JoinResDto {
+
+		// TODO: OAuth Type 등 추가 정보 필요
+		private String name;
+		private String email;
+		private RoleType role;
+
+		public JoinResDto(User user) {
+			this.name = user.getName();
+			this.email = user.getEmail();
+			this.role = user.getRole();
+		}
+	}
+}

--- a/src/main/java/oxahex/asker/server/error/ServiceException.java
+++ b/src/main/java/oxahex/asker/server/error/ServiceException.java
@@ -1,0 +1,17 @@
+package oxahex.asker.server.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import oxahex.asker.server.type.ErrorType;
+
+@Getter
+public class ServiceException extends RuntimeException {
+
+	HttpStatus httpStatus;
+	String errorMessage;
+
+	public ServiceException(ErrorType errorType) {
+		this.httpStatus = errorType.getHttpStatus();
+		this.errorMessage = errorType.getErrorMessage();
+	}
+}

--- a/src/main/java/oxahex/asker/server/service/AuthService.java
+++ b/src/main/java/oxahex/asker/server/service/AuthService.java
@@ -5,12 +5,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import oxahex.asker.server.domain.user.User;
 import oxahex.asker.server.domain.user.UserRepository;
+import oxahex.asker.server.dto.JoinDto.JoinReqDto;
+import oxahex.asker.server.dto.JoinDto.JoinResDto;
 import oxahex.asker.server.error.AuthException;
+import oxahex.asker.server.error.ServiceException;
 import oxahex.asker.server.security.AuthUser;
 import oxahex.asker.server.type.ErrorType;
+import oxahex.asker.server.type.RoleType;
 
 @Slf4j
 @Service
@@ -18,6 +23,7 @@ import oxahex.asker.server.type.ErrorType;
 public class AuthService implements UserDetailsService {
 
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
@@ -29,5 +35,36 @@ public class AuthService implements UserDetailsService {
 		// TODO: 토큰 발급 여기에서
 
 		return new AuthUser(user);
+	}
+
+	/**
+	 * 유저 생성
+	 * <p> 사용자 Name, Email, Password 를 받아 새로운 유저 생성
+	 * <p> 검증: Email 중복 여부
+	 *
+	 * @param joinReqDto name, email, password
+	 * @return 생성된 User Entity
+	 */
+	public JoinResDto createUser(JoinReqDto joinReqDto) {
+
+		log.info("[유저 생성][email={}]", joinReqDto.getEmail());
+
+		// 유저 생성 시 이메일 중복 검증
+		validateEmail(joinReqDto.getEmail());
+
+		User user = userRepository.save(User.builder()
+				.name(joinReqDto.getName())
+				.email(joinReqDto.getEmail())
+				.password(passwordEncoder.encode(joinReqDto.getPassword()))
+				.role(RoleType.USER)
+				.build());
+
+		return new JoinResDto(user);
+	}
+
+	private void validateEmail(String email) {
+		if (userRepository.existsByEmail(email)) {
+			throw new ServiceException(ErrorType.EMAIL_CONFLICT);
+		}
 	}
 }

--- a/src/main/java/oxahex/asker/server/type/ErrorType.java
+++ b/src/main/java/oxahex/asker/server/type/ErrorType.java
@@ -11,7 +11,10 @@ public enum ErrorType {
 	// 인증/인가
 	AUTHENTICATION_FAILURE(HttpStatus.UNAUTHORIZED, "인증 정보가 없거나 올바르지 않습니다."),
 	AUTHORIZATION_FAILURE(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-	TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 토큰입니다.");
+	TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+
+	// 중복
+	EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String errorMessage;


### PR DESCRIPTION
#7 
- 비밀번호 암호화 저장
- 이메일 중복 검증 및 이메일 중복 시 CONFLICT 반환
- 이메일 회원가입 시 유저 권한은 `USER`로 기본 생성

## 비밀번호 암호화 저장
PaswordEncoder 빈을 주입 받아 User 객체 생성, 저장 시 암호화된 비밀번호를 DB에 저장

```java
// 유저 생성 시 이메일 중복 검증
validateEmail(joinReqDto.getEmail());

User user = userRepository.save(User.builder()
		.name(joinReqDto.getName())
		.email(joinReqDto.getEmail())
		.password(passwordEncoder.encode(joinReqDto.getPassword()))
		.role(RoleType.USER)
		.build());
```
## 이메일 중복 검증
existByEmail 메서드 쿼리로 중복 확인, 중복 시 conflict 응답
```java
private void validateEmail(String email) {
	if (userRepository.existsByEmail(email)) {
		throw new ServiceException(ErrorType.EMAIL_CONFLICT);
	}
}
```