### PR TITLE
특정 질문에 답변하기 기능 구현

### DIFF
--- a/src/main/java/oxahex/asker/server/controller/DispatchController.java
+++ b/src/main/java/oxahex/asker/server/controller/DispatchController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import oxahex.asker.server.dto.AnswerDto.AnswerInfoDto;
+import oxahex.asker.server.dto.AnswerDto.AnswerReqDto;
 import oxahex.asker.server.dto.AskDto.AskInfoDto;
 import oxahex.asker.server.dto.AskDto.AskReqDto;
 import oxahex.asker.server.dto.ResponseDto;
@@ -45,6 +47,30 @@ public class DispatchController {
 
 		return new ResponseEntity<>(
 				new ResponseDto<>("성공적으로 질문했습니다.", askInfoDto),
+				HttpStatus.CREATED
+		);
+	}
+
+	/**
+	 * 특정 질문에 답변하기
+	 *
+	 * @param answerReqDto 답변 생성 요청 Body
+	 * @param authUser     로그인 유저
+	 * @return 생성한 답변 및 질문 정보 응답
+	 */
+	@PostMapping("/answer")
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<AnswerInfoDto>> dispatchAnswer(
+			@RequestBody @Valid AnswerReqDto answerReqDto,
+			@AuthenticationPrincipal AuthUser authUser
+	) {
+
+		log.info("[답변하기]");
+
+		AnswerInfoDto answerInfoDto = dispatchService.dispatchAnswer(authUser, answerReqDto);
+
+		return new ResponseEntity<>(
+				new ResponseDto<>("성공적으로 답변했습니다.", answerInfoDto),
 				HttpStatus.CREATED
 		);
 	}

--- a/src/main/java/oxahex/asker/server/domain/ask/AskRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/ask/AskRepository.java
@@ -1,9 +1,14 @@
 package oxahex.asker.server.domain.ask;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AskRepository extends JpaRepository<Ask, Long> {
+
+	@Query("select a from Ask a inner join Dispatch d ON a.id = d.ask.id where d.ask.id = :askId AND d.answerUser.id = :userId")
+	Optional<Ask> findDispatchedAsk(Long askId, Long userId);
 
 }

--- a/src/main/java/oxahex/asker/server/dto/AnswerDto.java
+++ b/src/main/java/oxahex/asker/server/dto/AnswerDto.java
@@ -1,0 +1,48 @@
+package oxahex.asker.server.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import oxahex.asker.server.domain.answer.Answer;
+import oxahex.asker.server.dto.AskDto.AskInfoDto;
+
+public class AnswerDto {
+
+	@Getter
+	@Setter
+	public static class AnswerReqDto {
+
+		@NotNull
+		@Max(value = Long.MAX_VALUE, message = "올바른 값이 아닙니다.")
+		private Long askId;
+
+		@NotEmpty(message = "답변 내용을 입력해주세요.")
+		@Pattern(regexp = "^.{10,800}$", message = "답변 내용은 최소 10자, 최대 800자 까지 입력할 수 있습니다.")
+		private String contents;
+	}
+
+	@Getter
+	@Setter
+	public static class AnswerInfoDto {
+
+		private Long answerId;
+		private String contents;
+		private AskInfoDto ask;
+		private LocalDateTime createdAt;
+
+		public static AnswerInfoDto of(Answer answer) {
+
+			AnswerInfoDto answerInfo = new AnswerInfoDto();
+			answerInfo.setAnswerId(answer.getId());
+			answerInfo.setContents(answer.getContents());
+			answerInfo.setAsk(AskInfoDto.of(answer.getAsk()));
+			answerInfo.setCreatedAt(answer.getCreatedAt());
+
+			return answerInfo;
+		}
+	}
+}

--- a/src/main/java/oxahex/asker/server/dto/AskDto.java
+++ b/src/main/java/oxahex/asker/server/dto/AskDto.java
@@ -30,14 +30,14 @@ public class AskDto {
 
 		private Long askId;
 		private String contents;
-		private LocalDateTime createdDate;
+		private LocalDateTime createdAt;
 
 		public static AskInfoDto of(Ask ask) {
 
 			AskInfoDto askInfo = new AskInfoDto();
 			askInfo.setAskId(ask.getId());
 			askInfo.setContents(ask.getContents());
-			askInfo.setCreatedDate(ask.getCreatedAt());
+			askInfo.setCreatedAt(ask.getCreatedAt());
 
 			return askInfo;
 		}

--- a/src/main/java/oxahex/asker/server/type/ErrorType.java
+++ b/src/main/java/oxahex/asker/server/type/ErrorType.java
@@ -17,7 +17,10 @@ public enum ErrorType {
 	EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 
 	// 유저
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다.");
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+
+	// 답변
+	ASK_FORBIDDEN(HttpStatus.FORBIDDEN, "답변 권한이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String errorMessage;


### PR DESCRIPTION
#11 
- 로그인 유저 본인에게 온 질문에만 답변 가능하도록 처리

```java
// 답변 가능한 질문인지 확인
Ask ask = askRepository.findDispatchedAsk(answerReqDto.getAskId(), authUser.getUser().getId())
	.orElseThrow(() -> new ServiceException(ErrorType.ASK_FORBIDDEN));

// 답변 생성
Answer answer = answerRepository.save(Answer.builder()
	.answerUser(authUser.getUser())
	.ask(ask)
	.contents(answerReqDto.getContents())
	.build());
```

## 로그인 유저 본인에게 온 질문만 답변 가능하도록 처리
답변 가능 질문인지 확인 시 다음과 같이 쿼리를 지정하여 구현
```java
@Query("select a from Ask a inner join Dispatch d ON a.id = d.ask.id where d.ask.id = :askId AND d.answerUser.id = :userId")
Optional<Ask> findDispatchedAsk(Long askId, Long userId);
```
Dispatch Table과 Ask Table을 JOIN 처리하여 전송 내역에 등록된 질문만 가져오도록 처리
