### PR TITLE
받은 질문 내역 조회 기능 구현

### DIFF
--- a/src/main/java/oxahex/asker/server/controller/AskController.java
+++ b/src/main/java/oxahex/asker/server/controller/AskController.java
@@ -1,0 +1,59 @@
+package oxahex.asker.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import oxahex.asker.server.dto.AskDto.AskListDto;
+import oxahex.asker.server.dto.ResponseDto;
+import oxahex.asker.server.security.AuthUser;
+import oxahex.asker.server.service.AskService;
+import oxahex.asker.server.type.SortType;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/asks")
+@RequiredArgsConstructor
+public class AskController {
+
+	private final AskService askService;
+
+	/**
+	 * 로그인 유저가 받은 질문 내역 조회
+	 *
+	 * @param authUser 로그인 유저
+	 * @param page     페이지 번호
+	 * @param size     페이지 당 크기
+	 * @param sort     정렬 타입
+	 * @return 받은 질문 내역
+	 */
+	@GetMapping
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<AskListDto>> getDispatchedAsk(
+			@AuthenticationPrincipal AuthUser authUser,
+			@RequestParam(defaultValue = "0") Integer page,
+			@RequestParam(defaultValue = "10") Integer size,
+			@RequestParam(defaultValue = "desc") SortType sort
+	) {
+
+		log.info("[받은 질문 목록 조회][email={}]", authUser.getUsername());
+
+		PageRequest pageRequest =
+				PageRequest.of(page, size, Sort.by(sort.getDirection(), "createdAt"));
+
+		AskListDto askListDto = askService.getAskList(authUser.getUser().getId(), pageRequest);
+
+		return new ResponseEntity<>(
+				new ResponseDto<>("받은 질문 내역을 조회했습니다.", askListDto),
+				HttpStatus.OK
+		);
+	}
+}

--- a/src/main/java/oxahex/asker/server/domain/ask/AskRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/ask/AskRepository.java
@@ -1,14 +1,22 @@
 package oxahex.asker.server.domain.ask;
 
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AskRepository extends JpaRepository<Ask, Long> {
 
+	// DISPATCH 테이블 ask_id, answer_user_id가 일치하는 ASK 데이터만 조회
 	@Query("select a from Ask a inner join Dispatch d ON a.id = d.ask.id where d.ask.id = :askId AND d.answerUser.id = :userId")
 	Optional<Ask> findDispatchedAsk(Long askId, Long userId);
+
+	// DISPATCH 테이블 answer_user_id와 일치하는 ASK 데이터 조회
+	@Query("select a from Ask as a join Dispatch as d on a.id = d.ask.id where d.answerUser.id = :userId")
+	Page<Ask> findAllDispatchedAsks(@Param("userId") Long userId, PageRequest pageRequest);
 
 }

--- a/src/main/java/oxahex/asker/server/dto/AskDto.java
+++ b/src/main/java/oxahex/asker/server/dto/AskDto.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.domain.Page;
 import oxahex.asker.server.domain.ask.Ask;
 
 public class AskDto {
@@ -40,6 +41,21 @@ public class AskDto {
 			askInfo.setCreatedAt(ask.getCreatedAt());
 
 			return askInfo;
+		}
+	}
+
+	@Getter
+	@Setter
+	public static class AskListDto {
+
+		private Page<AskInfoDto> asks;
+
+		public static AskListDto of(Page<Ask> askList) {
+
+			AskListDto askListDto = new AskListDto();
+			askListDto.setAsks(askList.map(AskInfoDto::of));
+
+			return askListDto;
 		}
 	}
 }

--- a/src/main/java/oxahex/asker/server/service/AskService.java
+++ b/src/main/java/oxahex/asker/server/service/AskService.java
@@ -1,0 +1,36 @@
+package oxahex.asker.server.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import oxahex.asker.server.domain.ask.Ask;
+import oxahex.asker.server.domain.ask.AskRepository;
+import oxahex.asker.server.dto.AskDto.AskListDto;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AskService {
+
+	private final AskRepository askRepository;
+
+	/**
+	 * 유저가 확인 가능한 질문 목록 조회
+	 *
+	 * @param userId      로그인 유저 아이디
+	 * @param pageRequest 조회 조건
+	 * @return 받은 질문 목록
+	 */
+	@Transactional(readOnly = true)
+	public AskListDto getAskList(Long userId, PageRequest pageRequest) {
+
+		// 해당 유저가 받은 질문 목록 조회
+		Page<Ask> askList =
+				askRepository.findAllDispatchedAsks(userId, pageRequest);
+
+		return AskListDto.of(askList);
+	}
+}


### PR DESCRIPTION
#17 
- 로그인 유저만 접근 가능
- 받은 질문 내역 조회 기능 구현

## 로그인 유저만 접근 가능
API 요청 시 어떤 유저의 질문 내역을 조회할 것인지 파라미터를 받지 않고,
로그인 시 발급 받는 JWT 토큰에 명시한 유저의 아이디로 조회

## 받은 질문 내역 조회 기능
쿼리를 이용하여 DISPATCH 테이블과 조인.
DISPATCH(전송) - 어떤 질문이 누구에게 전송되어야 하는지에 대한 정보가 있으므로
DISPATCH 테이블의 answer_user_id와 로그인 유저 id가 일치하는 컬럼의 ask_id로 ASK 데이터 조회

```java
// DISPATCH 테이블 answer_user_id와 일치하는 ASK 데이터 조회
@Query("select a from Ask as a join Dispatch as d on a.id = d.ask.id where d.answerUser.id = :userId")
Page<Ask> findAllDispatchedAsks(@Param("userId") Long userId, PageRequest pageRequest);
```