### PR TITLE
토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/oxahex/asker/server/cache/RedisRepository.java
+++ b/src/main/java/oxahex/asker/server/cache/RedisRepository.java
@@ -38,6 +38,21 @@ public class RedisRepository {
 	}
 
 	/**
+	 * Redis 데이터 조회
+	 *
+	 * @param key 조회할 데이터 키
+	 * @return 조회한 데이터
+	 */
+	public String get(RedisType type, String key) {
+
+		if (isExists(type.getPrefix() + key)) {
+			return (String) redisTemplate.opsForValue().get(key);
+		} else {
+			return null;
+		}
+	}
+
+	/**
 	 * Redis 데이터 존재 여부 확인
 	 *
 	 * @param key 확인하려는 데이터의 키

--- a/src/main/java/oxahex/asker/server/controller/AuthController.java
+++ b/src/main/java/oxahex/asker/server/controller/AuthController.java
@@ -6,13 +6,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import oxahex.asker.server.dto.JoinDto.JoinReqDto;
 import oxahex.asker.server.dto.JoinDto.JoinResDto;
 import oxahex.asker.server.dto.ResponseDto;
+import oxahex.asker.server.dto.TokenDto;
+import oxahex.asker.server.security.AuthUser;
 import oxahex.asker.server.service.AuthService;
 
 @Slf4j
@@ -43,6 +47,30 @@ public class AuthController {
 
 		return new ResponseEntity<>(
 				new ResponseDto<>("회원 가입이 완료되었습니다.", joinResDto),
+				HttpStatus.CREATED
+		);
+	}
+
+	/**
+	 * JWT Access Token 재발급
+	 * <p> Access Token 만료 시 프론트에서 Authorization Header에 Refresh Token 전송
+	 *
+	 * @param refreshToken 헤더 Refresh Token 값
+	 * @param authUser     로그인 유저
+	 * @return JWT Access Token
+	 */
+	@PostMapping(path = "/token", headers = HEADER)
+	public ResponseEntity<ResponseDto<TokenDto>> reIssueAccessToken(
+			@RequestHeader(HEADER) String refreshToken,
+			@AuthenticationPrincipal AuthUser authUser
+	) {
+
+		log.info("[JWT Access Token 재발급][email={}]", authUser.getUsername());
+
+		TokenDto tokenDto = authService.reIssueAccessToken(authUser, refreshToken);
+
+		return new ResponseEntity<>(
+				new ResponseDto<>("토큰이 정상적으로 재발급되었습니다.", tokenDto),
 				HttpStatus.CREATED
 		);
 	}

--- a/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
+++ b/src/main/java/oxahex/asker/server/domain/user/UserRepository.java
@@ -2,6 +2,8 @@ package oxahex.asker.server.domain.user;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 
 	boolean existsByEmail(String email);
+
+	@Query("select u.jwtToken from User as u where u.email = :email")
+	String findRefreshToken(@Param("email") String email);
 }

--- a/src/main/java/oxahex/asker/server/dto/LoginDto.java
+++ b/src/main/java/oxahex/asker/server/dto/LoginDto.java
@@ -31,13 +31,13 @@ public class LoginDto {
 		private String name;
 		private String email;
 		private RoleType role;
-		private String token;
+		private TokenDto token;
 
-		public LoginResDto(User user, String token) {
+		public LoginResDto(User user, TokenDto tokenDto) {
 			this.name = user.getName();
 			this.email = user.getEmail();
 			this.role = user.getRole();
-			this.token = token;
+			this.token = tokenDto;
 		}
 	}
 }

--- a/src/main/java/oxahex/asker/server/dto/TokenDto.java
+++ b/src/main/java/oxahex/asker/server/dto/TokenDto.java
@@ -1,0 +1,5 @@
+package oxahex.asker.server.dto;
+
+public record TokenDto(String accessToken, String refreshToken) {
+
+}

--- a/src/main/java/oxahex/asker/server/security/AuthenticationFilter.java
+++ b/src/main/java/oxahex/asker/server/security/AuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import oxahex.asker.server.dto.LoginDto.LoginReqDto;
 import oxahex.asker.server.dto.LoginDto.LoginResDto;
+import oxahex.asker.server.dto.TokenDto;
 import oxahex.asker.server.error.AuthException;
 import oxahex.asker.server.service.JwtTokenService;
 import oxahex.asker.server.type.ErrorType;
@@ -68,11 +69,11 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
 		AuthUser authUser = (AuthUser) authResult.getPrincipal();
 
-		// Access Token
+		// Access Token, Refresh Token 생성
 		String accessToken = JwtTokenService.create(authUser, JwtTokenType.ACCESS_TOKEN);
-
-		// Refresh Token
 		String refreshToken = JwtTokenService.create(authUser, JwtTokenType.REFRESH_TOKEN);
+
+		TokenDto tokenDto = new TokenDto(accessToken, refreshToken);
 
 		// Token, 로그인 유저 정보 응답
 		ResponseUtil.success(
@@ -80,7 +81,7 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 				response,
 				HttpStatus.OK,
 				"정상적으로 로그인 되었습니다.",
-				new LoginResDto(authUser.getUser(), accessToken)
+				new LoginResDto(authUser.getUser(), tokenDto)
 		);
 	}
 

--- a/src/main/java/oxahex/asker/server/type/ErrorType.java
+++ b/src/main/java/oxahex/asker/server/type/ErrorType.java
@@ -12,6 +12,7 @@ public enum ErrorType {
 	AUTHENTICATION_FAILURE(HttpStatus.UNAUTHORIZED, "인증 정보가 없거나 올바르지 않습니다."),
 	AUTHORIZATION_FAILURE(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 	TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 토큰입니다."),
+	TOKEN_REISSUE_FAILURE(HttpStatus.UNAUTHORIZED, "토큰 재발급에 실패했습니다."),
 
 	// 이메일
 	EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),


### PR DESCRIPTION
#21 
- 토큰 재발급 기능 구현
- 로그인 시 JSON 응답으로 Access Token, Refresh Token 발급하도록 변경
- 재발급 요청 시 Redis에 캐시된 토큰 1차 조회, 없는 경우 RDB에서 가져와 값이 같은지 비교하도록 처리